### PR TITLE
CWT-2494 - Handle null FileSizeInBytes, erroring Zencoder response

### DIFF
--- a/Source/Zencoder/HttpPostNotificationInput.cs
+++ b/Source/Zencoder/HttpPostNotificationInput.cs
@@ -72,7 +72,7 @@ namespace Zencoder
         /// Gets or sets the input file size.
         /// </summary>
         [JsonProperty("file_size_in_bytes")]
-        public long FileSizeInBytes { get; set; }
+        public long? FileSizeInBytes { get; set; }
 
         /// <summary>
         /// Gets or sets the input width.

--- a/Source/Zencoder/HttpPostNotificationOutput.cs
+++ b/Source/Zencoder/HttpPostNotificationOutput.cs
@@ -134,5 +134,23 @@ namespace Zencoder
         /// </summary>
         [JsonProperty("type")]
         public OutputType OutputType { get; set; }
+
+        /// <summary>
+        /// error type, eg "DownloadAccessDeniedError"
+        /// </summary>
+        [JsonProperty("error_class")]
+        public string ErrorClass { get; set; }
+
+        /// <summary>
+        /// Long description of error for human consumption
+        /// </summary>
+        [JsonProperty("error_message")]
+        public string ErrorMessage { get; set; }
+
+        /// <summary>
+        /// url for help page with more information about the error
+        /// </summary>
+        [JsonProperty("error_link")]
+        public string ErrorLink { get; set; }
     }
 }

--- a/Source/Zencoder/Properties/AssemblyInfo.cs
+++ b/Source/Zencoder/Properties/AssemblyInfo.cs
@@ -24,10 +24,10 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 
 // Used for NuGet packaging, uses semantic versioning: major.minor.patch-prerelease.
-[assembly: AssemblyInformationalVersion("1.2.0")]
+[assembly: AssemblyInformationalVersion("1.3.0")]
 
 // Keep this the same as AssemblyInformationalVersion.
-[assembly: AssemblyFileVersion("1.2.0")]
+[assembly: AssemblyFileVersion("1.3.0")]
 
 // ONLY change this when the major version changes; never with minor/patch/build versions.
 [assembly: AssemblyVersion("1.0.0.0")]


### PR DESCRIPTION
When a corrupt file is sent to Zencoder, the Input object in the OutputNotification has a null value for FileSizeInBytes, and some error information that can help diagnose the issue.

This PR allows the notification to be deserialized by making the FileSizeInBytes nullable, and adds some Error attributes so we can log them for debugging.